### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "jwt-simple": "^0.5.6",
     "material-ui": "^0.20.2",
     "mdbreact": "^4.11.0",
-    "npm": "^6.9.0",
     "photoeditorsdk": "^4.18.0",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",


### PR DESCRIPTION

Hello ncampbell89!

It seems like you have npm as one of your (dev-) dependency in facemusicClient.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
